### PR TITLE
Move API reference intro out of RAML

### DIFF
--- a/load-balancer/api-docs/api-reference.rst
+++ b/load-balancer/api-docs/api-reference.rst
@@ -4,4 +4,7 @@
 **API Reference**
 ===================
 
-Learn about the available |product name| resources and methods and see examples.
+Learn about |product name| API operations and review examples showing how to   
+view, manage, and configure load balancer devices and get information about usage
+statistics and events. 
+


### PR DESCRIPTION
API reference intro included in RAML was deleted.  Moved information to the API reference overview section, which is part of the human-generated, context-setting content.
