### PR TITLE
Update get-credentials.rst

### DIFF
--- a/load-balancer/api-docs/common-gs/get-credentials.rst
+++ b/load-balancer/api-docs/common-gs/get-credentials.rst
@@ -5,7 +5,7 @@ Get your credentials
 ====================
 
 To communicate with Rackspace services by using the REST API, you need
-your MyRackspace Cloud account username, API key, and account number.
+your MyRackspace account username, API key, and account number.
 
 Complete the following steps to get your credentials:
 


### PR DESCRIPTION
remove "cloud" from account reference to avoid confusion for dedicated customers