### PR TITLE
BPI-776: changed confusing references of {core_id} and {tenant_id} to…

### DIFF
--- a/load-balancer/api-docs/adx-api-reference/index.rst
+++ b/load-balancer/api-docs/adx-api-reference/index.rst
@@ -10,7 +10,7 @@ response examples.
 Use the following base endpoint to
 :ref:`submit API requests <send-api-requests>`.
 
-https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
+https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers
 
 
 .. toctree:: :hidden:

--- a/load-balancer/api-docs/adx-api-reference/index.rst
+++ b/load-balancer/api-docs/adx-api-reference/index.rst
@@ -10,7 +10,7 @@ response examples.
 Use the following base endpoint to
 :ref:`submit API requests <send-api-requests>`.
 
-https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant\_id}/loadbalancers
+https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
 
 
 .. toctree:: :hidden:

--- a/load-balancer/api-docs/common-gs/auth-using-curl.rst
+++ b/load-balancer/api-docs/common-gs/auth-using-curl.rst
@@ -137,7 +137,7 @@ request, prefix the variable name with a ``$``, for example ``$ENDPOINT``.
 
    .. code::
 
-      $ export TENANT_ID="tenant-id"
+      $ export account_id="tenant-id"
 
 
 #. In the ``service catalog`` section of the authentication response, copy the

--- a/load-balancer/api-docs/common-gs/auth-using-curl.rst
+++ b/load-balancer/api-docs/common-gs/auth-using-curl.rst
@@ -137,7 +137,7 @@ request, prefix the variable name with a ``$``, for example ``$ENDPOINT``.
 
    .. code::
 
-      $ export account_id="tenant-id"
+      $ export ACCOUNT_ID="account-id"
 
 
 #. In the ``service catalog`` section of the authentication response, copy the

--- a/load-balancer/api-docs/common-gs/auth-using-curl.rst
+++ b/load-balancer/api-docs/common-gs/auth-using-curl.rst
@@ -42,7 +42,7 @@ response that includes the following information:
 
 In the following example, the ellipsis (...)  represents other service
 endpoints, which  are not shown. The values shown in this and other examples
-vary because the information  returned is specific to your account.
+vary because the information returned is specific to your account.
 
 
 **Example: Authentication response**
@@ -137,7 +137,7 @@ request, prefix the variable name with a ``$``, for example ``$ENDPOINT``.
 
    .. code::
 
-      $ export ACCOUNT_ID="account-id"
+      $ export TENANT="tenant-id"
 
 
 #. In the ``service catalog`` section of the authentication response, copy the

--- a/load-balancer/api-docs/f5-api-reference/index.rst
+++ b/load-balancer/api-docs/f5-api-reference/index.rst
@@ -10,7 +10,7 @@ Learn about the API resources and operations to manage |F5| and review request a
 
 Use the following :ref:`Base URL <baseurlf5>` to submit API requests:
 
-``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}``
+``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}``
 
 .. toctree::
    :maxdepth: 1

--- a/load-balancer/api-docs/f5-api-reference/index.rst
+++ b/load-balancer/api-docs/f5-api-reference/index.rst
@@ -10,7 +10,7 @@ Learn about the API resources and operations to manage |F5| and review request a
 
 Use the following :ref:`Base URL <baseurlf5>` to submit API requests:
 
-``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{core_id}``
+``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}``
 
 .. toctree::
    :maxdepth: 1

--- a/load-balancer/api-docs/general-api-info/service-access-endpoints.rst
+++ b/load-balancer/api-docs/general-api-info/service-access-endpoints.rst
@@ -6,7 +6,7 @@ Service access
 
 Use the following global endpoint to submit requests to the |apiservice|.
 
-``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}``
+``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}``
 
 Use the following URIs to submit requests to manage load balancers of a
 specific type:
@@ -14,12 +14,12 @@ specific type:
 |F5|
 ~~~~
 
-    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/``
+    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/``
 
 |ADX|
 ~~~~~
 
-    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers/``
+    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers/``
 
 .. note::
 

--- a/load-balancer/api-docs/general-api-info/service-access-endpoints.rst
+++ b/load-balancer/api-docs/general-api-info/service-access-endpoints.rst
@@ -6,7 +6,7 @@ Service access
 
 Use the following global endpoint to submit requests to the |apiservice|.
 
-``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}``
+``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}``
 
 Use the following URIs to submit requests to manage load balancers of a
 specific type:
@@ -14,12 +14,12 @@ specific type:
 |F5|
 ~~~~
 
-    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/``
+    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/``
 
 |ADX|
 ~~~~~
 
-    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers/``
+    ``https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers/``
 
 .. note::
 

--- a/load-balancer/api-docs/index.rst
+++ b/load-balancer/api-docs/index.rst
@@ -4,7 +4,7 @@
 Rackspace |product name| API |contract version|
 ===============================================
 
-*Last updated:* |today|
+*Last updated:* |today| 
 
 The |product name| service enables developers to programmatically view and
 manage their existing dedicated hardware load balancer resources such as

--- a/load-balancer/src/docs/f5-load-balancer/api-orig.md
+++ b/load-balancer/src/docs/f5-load-balancer/api-orig.md
@@ -1,4 +1,4 @@
-**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{core_id}
+**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
 
 
 		

--- a/load-balancer/src/docs/f5-load-balancer/api-orig.md
+++ b/load-balancer/src/docs/f5-load-balancer/api-orig.md
@@ -1,4 +1,4 @@
-**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
+**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}
 
 
 		

--- a/load-balancer/src/docs/f5-load-balancer/api-raml2md.md
+++ b/load-balancer/src/docs/f5-load-balancer/api-raml2md.md
@@ -1,5 +1,5 @@
 # F5 Load Balancer API documentation version 1 <br> <p style="font-size:17px; color:black"><em>Last modified date - June 6, 2016 </em></p><hr>
-https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
+https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}
 
 ### API Overview
 This API exposes methods to view and manage F5 Load Balancer resources

--- a/load-balancer/src/docs/f5-load-balancer/api-raml2md.md
+++ b/load-balancer/src/docs/f5-load-balancer/api-raml2md.md
@@ -1,5 +1,5 @@
 # F5 Load Balancer API documentation version 1 <br> <p style="font-size:17px; color:black"><em>Last modified date - June 6, 2016 </em></p><hr>
-https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{core_id}
+https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
 
 ### API Overview
 This API exposes methods to view and manage F5 Load Balancer resources

--- a/load-balancer/src/docs/f5-load-balancer/api-raml2md.rst
+++ b/load-balancer/src/docs/f5-load-balancer/api-raml2md.rst
@@ -14,7 +14,7 @@ Last modified date - June 6, 2016
 
    <hr>
 
-https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
+https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}
 
 API Overview
 ~~~~~~~~~~~~

--- a/load-balancer/src/docs/f5-load-balancer/api-raml2md.rst
+++ b/load-balancer/src/docs/f5-load-balancer/api-raml2md.rst
@@ -14,7 +14,7 @@ Last modified date - June 6, 2016
 
    <hr>
 
-https://bpi.automation.api.rackspacecloud.com/2.0/{tenant\_id}/f5loadbalancers/{core\_id}
+https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
 
 API Overview
 ~~~~~~~~~~~~

--- a/load-balancer/src/docs/f5-load-balancer/api.md
+++ b/load-balancer/src/docs/f5-load-balancer/api.md
@@ -1,4 +1,4 @@
-**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{core_id}
+**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
 
 
 		

--- a/load-balancer/src/docs/f5-load-balancer/api.md
+++ b/load-balancer/src/docs/f5-load-balancer/api.md
@@ -1,4 +1,4 @@
-**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
+**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}
 
 
 		

--- a/load-balancer/src/docs/f5-load-balancer/api.raml
+++ b/load-balancer/src/docs/f5-load-balancer/api.raml
@@ -1,7 +1,7 @@
 #%RAML 0.8
 title: F5 Load Balancer
 version: 1 <br> <p style="font-size:17px; color:black"><em>Last modified date - June 6, 2016 </em></p><hr>
-baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
+baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}
 documentation:
 - title: API Overview
   content: |
@@ -26,7 +26,7 @@ documentation:
     - **510**: An indeterminate error occurred. This is caused by an unexpected error.
 
 baseUriParameters:
-  account_id:
+  tenant_id:
     displayName: Tenant ID
     description: |
         The account number associated with the device_id

--- a/load-balancer/src/docs/f5-load-balancer/api.raml
+++ b/load-balancer/src/docs/f5-load-balancer/api.raml
@@ -1,7 +1,7 @@
 #%RAML 0.8
 title: F5 Load Balancer
 version: 1 <br> <p style="font-size:17px; color:black"><em>Last modified date - June 6, 2016 </em></p><hr>
-baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{core_id}
+baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
 documentation:
 - title: API Overview
   content: |
@@ -26,12 +26,12 @@ documentation:
     - **510**: An indeterminate error occurred. This is caused by an unexpected error.
 
 baseUriParameters:
-  tenant_id:
+  account_id:
     displayName: Tenant ID
     description: |
-        The account number associated with the core_id
+        The account number associated with the device_id
     type: integer
-  core_id:
+  device_id:
     displayName: CORE Device Number
     description: |
         The CORE device number for the loadbalancer.

--- a/load-balancer/src/docs/f5-load-balancer/api.rst
+++ b/load-balancer/src/docs/f5-load-balancer/api.rst
@@ -1,5 +1,5 @@
 **Endpoint:**
-https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant\_id}/f5loadbalancers/{core\_id}
+https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
 
 Retrieve load balancer details
 ------------------------------

--- a/load-balancer/src/docs/f5-load-balancer/api.rst
+++ b/load-balancer/src/docs/f5-load-balancer/api.rst
@@ -1,5 +1,5 @@
 **Endpoint:**
-https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/f5loadbalancers/{device_id}
+https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/f5loadbalancers/{device_id}
 
 Retrieve load balancer details
 ------------------------------

--- a/load-balancer/src/docs/load-balancer.api.v2/api.md
+++ b/load-balancer/src/docs/load-balancer.api.v2/api.md
@@ -1,4 +1,4 @@
-**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers
+**Endpoint:** https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
 
 
 		

--- a/load-balancer/src/docs/load-balancer.api.v2/api.raml
+++ b/load-balancer/src/docs/load-balancer.api.v2/api.raml
@@ -1,7 +1,7 @@
 #%RAML 0.8
 title: BPI - Load Balancer Service
 version: v2.0 <br> <p style="font-size:17px; color:black"><em>Last modified date - Oct 28, 2016 </em></p><hr>
-baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers
+baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
 documentation:
 - title: API Overview
   content: |
@@ -26,10 +26,10 @@ documentation:
     - **510**: An indeterminate error occurred. This is caused by an unexpected error.
 
 baseUriParameters:
-  tenant_id:
+  account_id:
     displayName: Tenant ID
     description: |
-        The account number associated with the core_id
+        The account number associated with the device_id
     type: integer
 
 mediaType: application/json

--- a/load-balancer/src/docs/load-balancer.api.v2/api.raml
+++ b/load-balancer/src/docs/load-balancer.api.v2/api.raml
@@ -1,7 +1,7 @@
 #%RAML 0.8
 title: BPI - Load Balancer Service
 version: v2.0 <br> <p style="font-size:17px; color:black"><em>Last modified date - Oct 28, 2016 </em></p><hr>
-baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
+baseUri: https://bpi.automation.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers
 documentation:
 - title: API Overview
   content: |
@@ -26,7 +26,7 @@ documentation:
     - **510**: An indeterminate error occurred. This is caused by an unexpected error.
 
 baseUriParameters:
-  account_id:
+  tenant_id:
     displayName: Tenant ID
     description: |
         The account number associated with the device_id

--- a/load-balancer/src/docs/load-balancer.api.v2/api.rst
+++ b/load-balancer/src/docs/load-balancer.api.v2/api.rst
@@ -1,5 +1,5 @@
 **Endpoint:**
-https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
+https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant_id}/loadbalancers
 
 Returns a complete info about loadbalancer
 ------------------------------------------

--- a/load-balancer/src/docs/load-balancer.api.v2/api.rst
+++ b/load-balancer/src/docs/load-balancer.api.v2/api.rst
@@ -1,5 +1,5 @@
 **Endpoint:**
-https://lb.dedicated.api.rackspacecloud.com/2.0/{tenant\_id}/loadbalancers
+https://lb.dedicated.api.rackspacecloud.com/2.0/{account_id}/loadbalancers
 
 Returns a complete info about loadbalancer
 ------------------------------------------


### PR DESCRIPTION
… {device_id} and {account_id} respectively since this is not a traditional cloud api.