### PR TITLE
Replace: polyfill

### DIFF
--- a/load-balancer/api-docs/_templates/scripts.html
+++ b/load-balancer/api-docs/_templates/scripts.html
@@ -121,5 +121,5 @@
 </script>
 <script src="https://docs.rackspace.com/assets/bundle.js"></script>
 <script
-    src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
+    src="https://polyfill-fastly.io/v3/polyfill.min.js?features=default%2CArray.prototype.find%2CArray.prototype.includes%2CPromise%2CObject.assign%2CObject.entries">
 </script>


### PR DESCRIPTION
@the2hill 
URL link available in GitHub: https://developer.rackspace.com/docs/dedicated-load-balancers/v2/ is landing to **Page has been moved**. 
Could please about the migration of the GitHub Repo: https://github.com/rackerlabs/docs-dedicated-networking.

If it migrated, then could you please merge PR.